### PR TITLE
Add LDAP attribute support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -113,6 +113,11 @@ LOCAL_TEMPLATE_DIR=False
 APP_DISPLAY_NAME='Filestore Web Access'
 APP_DISPLAY_NAME_SHORT='FWA'
 
+## LDAP
+LDAP_ENABLED=False
+LDAP_URI='ldaps://localhost.localdomain'
+LDAP_SEARCH_BASE=''
+
 ################################################################################
 
 # set up our application
@@ -121,16 +126,16 @@ app = BargateFlask(__name__)
 # load default config
 app.config.from_object(__name__)
 
-# try to load config from various paths 
+# try to load config from various paths
 if os.path.isfile('/etc/bargate.conf'):
 	app.config.from_pyfile('/etc/bargate.conf')
-elif os.path.isfile('/etc/bargate/bargate.conf'): 	
+elif os.path.isfile('/etc/bargate/bargate.conf'):
 	app.config.from_pyfile('/etc/bargate/bargate.conf')
-elif os.path.isfile('/data/fwa/bargate.conf'): 	
+elif os.path.isfile('/data/fwa/bargate.conf'):
 	app.config.from_pyfile('/data/fwa/bargate.conf')
-elif os.path.isfile('/data/bargate/bargate.conf'): 	
-	app.config.from_pyfile('/data/bargate/bargate.conf')	
-	
+elif os.path.isfile('/data/bargate/bargate.conf'):
+	app.config.from_pyfile('/data/bargate/bargate.conf')
+
 ## Set up logging to file
 file_handler = RotatingFileHandler(app.config['LOG_DIR'] + '/' + app.config['LOG_FILE'], 'a', app.config['LOG_FILE_MAX_SIZE'], app.config['LOG_FILE_MAX_FILES'])
 file_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'))
@@ -144,7 +149,7 @@ else:
 	app.logger.setLevel(logging.INFO)
 	file_handler.setLevel(logging.INFO)
 
-# load user defined templates 
+# load user defined templates
 app.load_user_templates()
 
 ## Output some startup info
@@ -183,7 +188,7 @@ Further Details:
 """))
 
 	app.logger.addHandler(mail_handler)
-	
+
 ## Debug Toolbar
 if app.config['DEBUG_TOOLBAR']:
 	app.debug = True
@@ -204,7 +209,7 @@ import bargate.mime
 import bargate.settings
 
 # load anti csrf function reference into template engine
-app.jinja_env.globals['csrf_token']      = core.generate_csrf_token 
+app.jinja_env.globals['csrf_token']      = core.generate_csrf_token
 app.jinja_env.globals['get_user_theme']  = settings.get_user_theme
 app.jinja_env.globals['get_user_navbar'] = settings.get_user_navbar
 

--- a/__init__.py
+++ b/__init__.py
@@ -114,9 +114,12 @@ APP_DISPLAY_NAME='Filestore Web Access'
 APP_DISPLAY_NAME_SHORT='FWA'
 
 ## LDAP
-LDAP_ENABLED=False
+LDAP_HOMEDIR=False
 LDAP_URI='ldaps://localhost.localdomain'
 LDAP_SEARCH_BASE=''
+# Default to homeDirectory as most people are using AD
+LDAP_HOME_ATTRIBUTE='homeDirectory'
+LDAP_USER_ATTRIBUTE='sAMAccountName'
 LDAP_BIND_USER=''
 LDAP_BIND_PW=''
 

--- a/views.py
+++ b/views.py
@@ -80,7 +80,7 @@ def login():
 			app.logger.info('User "' + session['username'] + '" logged in from "' + request.remote_addr + '" using ' + request.user_agent.string)
 
 			## IF LDAP is enabled attempt to log the LDAP home
-			if app.config['LDAP_ENABLED'] == True:
+			if app.config['LDAP_HOMEDIR'] == True:
 				app.logger.info('User "' + session['username'] + '" LDAP home attribute ' + str(ldap_get_homedir(session['username'])))
 
 			## determine if "next" variable is set (the URL to be sent to)
@@ -106,7 +106,7 @@ def ldap_get_homedir(username):
 	## other than cn against AD in the long term
 	try:
 		l.simple_bind_s( (app.config['LDAP_BIND_USER']), (app.config['LDAP_BIND_PW']) )
-		results = l.search_s(app.config['LDAP_SEARCH_BASE'], ldap.SCOPE_SUBTREE,"(cn=" + request.form['username'] +")")
+		results = l.search_s(app.config['LDAP_SEARCH_BASE'], ldap.SCOPE_SUBTREE,(app.config['LDAP_USER_ATTRIBUTE']) + "=" + request.form['username'])
 	except ldap.LDAPError as e:
 		flash('LDAP Bind error: ' + e.__str__(),'alert-danger')
 		return redirect(url_for('login'))
@@ -117,11 +117,11 @@ def ldap_get_homedir(username):
 		attrs	= result[1]
 
 		if not dn == None:
-			if "homeDirectory" in attrs:
-				if type(attrs['homeDirectory']) is list:
-					return attrs['homeDirectory'][0]
+			if (app.config['LDAP_HOME_ATTRIBUTE']) in attrs:
+				if type(attrs[app.config['LDAP_HOME_ATTRIBUTE']]) is list:
+					return attrs[app.config['LDAP_HOME_ATTRIBUTE']][0]
 				else:
-					return str(attrs['homeDirectory'])
+					return str(attrs[app.config['LDAP_HOME_ATTRIBUTE']])
 		return None
 
 ################################################################################

--- a/views.py
+++ b/views.py
@@ -59,6 +59,9 @@ def login():
 			## Set logged in (if we got this far)
 			session['logged_in'] = True
 			session['username']  = request.form['username']
+			
+			## Lower case all usernames so that keys in redis always match no matter what case-value the user enters
+			session['username'] = session['username'].lower()
 
 			## Check if the user selected "Log me out when I close the browser"
 			permanent = request.form.get('sec',default="")


### PR DESCRIPTION
This adds support for the LDAP attributes we plan to use to provide access to initially user home directories and in future potentially all shares that are configured and looked up in an LDAP directory.

The additions include adding a function to get the home directory from LDAP for a particular user (with lots of help from Divad)  and logging this attribute.