### PR TITLE
Additional SMB path logging

### DIFF
--- a/views.py
+++ b/views.py
@@ -94,7 +94,10 @@ def login():
 
 					if app.config['LDAP_HOMEDIR_IS_UNC']:
 						if session['ldap_homedir'].startswith('\\\\'):
-							session['ldap_homedir'] = session['ldap_homedir'].replace('\\','smb://',1)
+							session['ldap_homedir'] = session['ldap_homedir'].replace('\\\\','smb://',1)
+						session['ldap_homedir'] = session['ldap_homedir'].replace('\\','/')
+					## Overkill but log it again anyway just to make sure we really have the value we think we should
+					app.logger.info('User "' + session['username'] + '" home SMB path ' + session['ldap_homedir'])
 				
 			## determine if "next" variable is set (the URL to be sent to)
 			next = request.form.get('next',default=None)


### PR DESCRIPTION
Maybe overkill, but log what we have immediately after we've munged the home directory path returned from LDAP to ensure it's something we can use. Should make troubleshooting easier in the long run as we're making some assumptions about what we get from LDAP currently.