### PR TITLE
Fixes for LDAP auth combined with LDAP home, "portal" login

### DIFF
--- a/core.py
+++ b/core.py
@@ -32,6 +32,13 @@ import random                 ## used in pwgen
 import string                 ## used in pwgen
 import ldap
 
+# For cookie decode
+from base64 import b64decode
+from itsdangerous import base64_decode
+import zlib
+import json
+import uuid
+
 ################################################################################
 
 def render_page(template_name, **kwargs):
@@ -88,7 +95,7 @@ def downtime_check(f):
 	def decorated_function(*args, **kwargs):
 		if app.config['DISABLE_APP']:
 			flash('Service Temporarily Unavailable - Normal service will be restored as soon as possible.','alert-warning')
-			bgnumber = randint(1,17)
+			bgnumber = randint(1,2)
 			## don't use render_page as it loads bookmarks and that might not work
 			return render_template('login.html', bgnumber=bgnumber)
 		return f(*args, **kwargs)
@@ -123,8 +130,8 @@ def before_request():
 
 	## Check CSRF key is valid
 	if request.method == "POST":
-		## login handler shouldn't have to be CSRF protected
-		if not request.endpoint == 'login':
+		## login handler and portal page shouldn't have to be CSRF protected
+		if not request.endpoint in ('login', 'portallogin'):
 			## check csrf token is valid
 			token = session.get('_csrf_token')
 			if not token or token != request.form.get('_csrf_token'):
@@ -434,3 +441,40 @@ def list_online_users(minutes=15):
     minutes = xrange(minutes)
     return g.redis.sunion(['online-users/%d' % (current - x)
                          for x in minutes])
+
+################################################################################
+#### Cookie decode for portal login
+
+def decode_session_cookie(cookie_data):
+	compressed = False
+	payload = cookie_data
+
+	if payload.startswith(b'.'):
+		compressed = True
+		payload = payload[1:]
+
+	data = payload.split(".")[0]
+	data = base64_decode(data)
+	if compressed:
+		data = zlib.decompress(data)
+
+	return data
+
+def flask_load_session_json(value):
+	def object_hook(obj):
+		if (len(obj) != 1):
+			return obj
+		the_key, the_value = next(obj.iteritems())
+		if the_key == 't':
+			return str(tuple(the_value))
+		elif the_key == 'u':
+			return str(uuid.UUID(the_value))
+		elif the_key == 'b':
+			return str(b64decode(the_value))
+		elif the_key == 'm':
+			return str(Markup(the_value))
+		elif the_key == 'd':
+			return str(parse_date(the_value))
+		return obj
+	return json.loads(value, object_hook=object_hook)
+

--- a/core.py
+++ b/core.py
@@ -471,12 +471,12 @@ def auth_user(username, password):
 							homedir_attribute = str(attrs[app.config['LDAP_HOME_ATTRIBUTE']	])
 
 						if homedir_attribute == None:
-							app.logger.error('ldap_get_homedir returned None for user ' + session['username'])
+							app.logger.error('ldap_get_homedir returned None for user ' + username)
 							flash("Profile Error: I could not find your home directory location","alert-danger")
 							abort(500)
 						else:
 							session['ldap_homedir'] = homedir_attribute
-							app.logger.debug('User "' + session['username'] + '" LDAP home attribute ' + session['ldap_homedir'])
+							app.logger.debug('User "' + username + '" LDAP home attribute ' + session['ldap_homedir'])
 
 							if app.config['LDAP_HOMEDIR_IS_UNC']:
 								if session['ldap_homedir'].startswith('\\\\'):
@@ -484,7 +484,7 @@ def auth_user(username, password):
 								session['ldap_homedir'] = session['ldap_homedir'].replace('\\','/')
 					
 							## Overkill but log it again anyway just to make sure we really have the value we think we should
-							app.logger.debug('User "' + session['username'] + '" home SMB path ' + session['ldap_homedir'])		
+							app.logger.debug('User "' + username + '" home SMB path ' + session['ldap_homedir'])		
 
 				## Return that LDAP auth succeeded
 				return True

--- a/views.py
+++ b/views.py
@@ -235,10 +235,3 @@ def portallogin():
 
 	return redirect(url_for(app.config['SHARES_DEFAULT']))
 
-@app.route('/portallogin2', methods=['POST', 'GET'])
-def portallogin2():
-	username = request.cookies.get('username')
-
-	app.logger.info('Getting username ' + username)
-	response = make_response(redirect(url_for(app.config['SHARES_DEFAULT'])))
-	return response


### PR DESCRIPTION
We've added some modifications to start supporting a "portal" authentication process that we will need to use in our environment. It needs some further work and you may not want to merge this component anyway.

Also added a fix for LDAP authentication combined with LDAP_HOMEDIR - the logging was trying to use `session['username']` before it had been populated. I've just updated it to stop trying to get the username from the session.

There's also I minor change I made to the number of login page background images searched for - I/we really need to turn that into a config option! :-)